### PR TITLE
Minor updates for HomeAssistant 2021.6

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,9 +1,11 @@
 {
   "domain": "flair",
   "name": "flair",
+  "version": "1.0.1",
   "documentation": "",
   "dependencies": [],
   "codeowners": [],
-  "requirements": []
+  "requirements": [],
+  "iot_class": "cloud_polling",
 }
 

--- a/sensor.py
+++ b/sensor.py
@@ -8,7 +8,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (CONF_NAME, CONF_MONITORED_CONDITIONS)
-from flair_api import make_client
+from .client import make_client
 
 CONF_CLIENT_ID = 'client_id'
 CONF_CLIENT_SECRET = 'client_secret'


### PR DESCRIPTION
Change to sensor.py resolves #3 
Change to manifest.json required by 2021.6 (see https://www.home-assistant.io/blog/2021/05/05/release-20215/#breaking-changes for "custom integrations") 